### PR TITLE
Implement burn mecanism fork

### DIFF
--- a/config/embedded/chiliz.json
+++ b/config/embedded/chiliz.json
@@ -31,6 +31,7 @@
     "grayGlacierBlock": 13189711,
     "shanghaiTime": 1716300000,
     "keplerTime": 1716300000,
+    "BurnTransactionFeeForkBlock": 14356983,
     "parlia": {
       "period": 3,
       "epoch": 28800

--- a/config/embedded/scoville.json
+++ b/config/embedded/scoville.json
@@ -19,6 +19,7 @@
     "nielsBlock": 0,
     "mirrorSyncBlock": 0,
     "brunoBlock": 0,
+    "BurnTransactionFeeForkBlock": 0,
     "parlia": {
       "period": 3,
       "epoch": 1200

--- a/config/embedded/spicy.json
+++ b/config/embedded/spicy.json
@@ -32,6 +32,7 @@
     "shanghaiTime": 1714381800,
     "keplerTime": 1714381800,
     "dragon8Time": 1714381800,
+    "BurnTransactionFeeForkBlock": 14396613,
     "parlia": {
       "period": 3,
       "epoch": 7200

--- a/params/config.go
+++ b/params/config.go
@@ -231,31 +231,32 @@ var (
 	}
 
 	ParliaTestChainConfig = &ChainConfig{
-		ChainID:             big.NewInt(2),
-		HomesteadBlock:      big.NewInt(0),
-		EIP150Block:         big.NewInt(0),
-		EIP155Block:         big.NewInt(0),
-		EIP158Block:         big.NewInt(0),
-		ByzantiumBlock:      big.NewInt(0),
-		ConstantinopleBlock: big.NewInt(0),
-		PetersburgBlock:     big.NewInt(0),
-		IstanbulBlock:       big.NewInt(0),
-		MuirGlacierBlock:    big.NewInt(0),
-		RamanujanBlock:      big.NewInt(0),
-		NielsBlock:          big.NewInt(0),
-		MirrorSyncBlock:     big.NewInt(0),
-		BrunoBlock:          big.NewInt(0),
-		EulerBlock:          big.NewInt(0),
-		NanoBlock:           big.NewInt(0),
-		MoranBlock:          big.NewInt(0),
-		GibbsBlock:          big.NewInt(0),
-		PlanckBlock:         big.NewInt(0),
-		LubanBlock:          big.NewInt(0),
-		PlatoBlock:          big.NewInt(0),
-		BerlinBlock:         big.NewInt(0),
-		LondonBlock:         big.NewInt(0),
-		HertzBlock:          big.NewInt(0),
-		HertzfixBlock:       big.NewInt(0),
+		ChainID:                     big.NewInt(2),
+		HomesteadBlock:              big.NewInt(0),
+		EIP150Block:                 big.NewInt(0),
+		EIP155Block:                 big.NewInt(0),
+		EIP158Block:                 big.NewInt(0),
+		ByzantiumBlock:              big.NewInt(0),
+		ConstantinopleBlock:         big.NewInt(0),
+		PetersburgBlock:             big.NewInt(0),
+		IstanbulBlock:               big.NewInt(0),
+		MuirGlacierBlock:            big.NewInt(0),
+		RamanujanBlock:              big.NewInt(0),
+		NielsBlock:                  big.NewInt(0),
+		MirrorSyncBlock:             big.NewInt(0),
+		BrunoBlock:                  big.NewInt(0),
+		EulerBlock:                  big.NewInt(0),
+		NanoBlock:                   big.NewInt(0),
+		MoranBlock:                  big.NewInt(0),
+		GibbsBlock:                  big.NewInt(0),
+		PlanckBlock:                 big.NewInt(0),
+		LubanBlock:                  big.NewInt(0),
+		PlatoBlock:                  big.NewInt(0),
+		BerlinBlock:                 big.NewInt(0),
+		LondonBlock:                 big.NewInt(0),
+		HertzBlock:                  big.NewInt(0),
+		HertzfixBlock:               big.NewInt(0),
+		BurnTransactionFeeForkBlock: big.NewInt(0),
 		Parlia: &ParliaConfig{
 			Period: 3,
 			Epoch:  200,
@@ -463,6 +464,9 @@ type ChainConfig struct {
 	DeployerFactoryBlock   *big.Int `json:"deployerFactoryBlock,omitempty"`
 	Dragon8Time            *uint64  `json:"dragon8Time,omitempty"`
 
+	// Test fork
+	BurnTransactionFeeForkBlock *big.Int `json:"burnTransactionFeeForkBlock,omitempty"`
+
 	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty" ` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
 	KeplerTime   *uint64 `json:"keplerTime,omitempty"`    // Kepler switch time (nil = no fork, 0 = already activated)
 	CancunTime   *uint64 `json:"cancunTime,omitempty" `   // Cancun switch time (nil = no fork, 0 = already on cancun)
@@ -562,7 +566,7 @@ func (c *ChainConfig) String() string {
 		Dragon8Time = big.NewInt(0).SetUint64(*c.Dragon8Time)
 	}
 
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, Hertzfix: %v, Dragon8Time: %v, ShanghaiTime: %v, KeplerTime: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Planck: %v,Luban: %v, Plato: %v, Hertz: %v, Hertzfix: %v, Dragon8Time: %v, ShanghaiTime: %v, KeplerTime: %v,BurnTransactionFeeForkBlock: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -597,6 +601,7 @@ func (c *ChainConfig) String() string {
 		Dragon8Time,
 		ShanghaiTime,
 		KeplerTime,
+		c.BurnTransactionFeeForkBlock,
 		engine,
 	)
 }
@@ -604,6 +609,11 @@ func (c *ChainConfig) String() string {
 // IsDragon8 returns whether num & timestamp represents a block number after the dragon8 fork
 func (c *ChainConfig) IsDragon8(time uint64) bool {
 	return isTimestampForked(c.Dragon8Time, time)
+}
+
+// IsBurnTransactionFeeForkBlock returns whether num is either equal to the burnTransactionFeeForkBlock block or greater.
+func (c *ChainConfig) IsBurnTransactionFeeForkBlock(num *big.Int) bool {
+	return isBlockForked(c.BurnTransactionFeeForkBlock, num)
 }
 
 // IsHomestead returns whether num is either equal to the homestead block or greater.


### PR DESCRIPTION
### Description

This pull request introduces a new feature to burn half of the transaction fees in the Parlia consensus engine. This change is activated via a configurable fork block number, `BurnTransactionFeeForkBlock`, specified in the chain configuration. The mechanism ensures that once the blockchain reaches this specified block number, half of the transaction fees are burned.
### Rationale

This is a part of a technical assessment task 

### Example

After the fork is activated at block number 14356983, the system will start burning half of the transaction fees. For instance, if a block has transaction fees totaling 100 tokens, 50 tokens will be burned.

**Example CLI or API response:**
- Before the fork block:
  - Transaction fees are fully distributed to validators.
- After the fork block:
  - Half of the transaction fees are burned, and the remaining half is distributed to validators.

### Changes

Notable changes:
* Added a new configuration parameter `BurnTransactionFeeForkBlock` in `config.go` to specify the fork block number.
* Updated the `distributeIncoming` function in `parlia.go` to implement the burn mechanism after the specified fork block.
* Modified the `chilliz.json` file to include the `BurnTransactionFeeForkBlock` parameter.
* Introduced logic to handle the burning of transaction fees and the distribution of the remaining balance to validators.

The detailed implementation involves:
1. Checking if the current block number is greater than or equal to the specified `BurnTransactionFeeForkBlock`.
2. Calculating the burn amount as half of the transaction fees.
3. Adjusting the balance of the system address to reflect the burned amount.
4. Distributing the remaining balance to validators.
